### PR TITLE
fix : CrossTrade - OVM_ETH address with tokenInfo

### DIFF
--- a/src/types/token/supportedToken.ts
+++ b/src/types/token/supportedToken.ts
@@ -50,10 +50,10 @@ export const supportedTokens: SupportedTokens_T = [
     tokenSymbol: "ETH",
     address: {
       MAINNET: "",
-      TITAN: TOKAMAK_CONTRACTS.OVM_ETH,
+      TITAN: TOKAMAK_CONTRACTS.WETH_ADDRESS,
       SEPOLIA: "",
       THANOS_SEPOLIA: THANOS_SEPOLIA_CONTRACTS.ETH_ADDRESS,
-      TITAN_SEPOLIA: TITAN_SEPOLIA_CONTRACTS.OVM_ETH,
+      TITAN_SEPOLIA: TITAN_SEPOLIA_CONTRACTS.WETH_ADDRESS,
     },
     decimals: 18,
     isNativeCurrency: [


### PR DESCRIPTION
## Summary

- Fix ETH address issue with CrossTrade withdraw

## Checklist

- [ ] ETH is available with CrossTrade option on the withdraw option modal 