### PR TITLE
fix: ignore unsupported tokens in tx history

### DIFF
--- a/src/staging/hooks/useBridgeHistory.ts
+++ b/src/staging/hooks/useBridgeHistory.ts
@@ -215,6 +215,7 @@ export const useWithdrawData = () => {
             amount,
             false
           );
+          if (!l1Token || !l2Token) return;
           const status = getStatus(currentStatus);
           const { blockTimestamps, transactionHashes } = getTransaction({
             currentStatus,
@@ -315,6 +316,8 @@ export const useDepositData = () => {
             amount,
             true
           );
+
+          if (!l1Token || !l2Token) return;
 
           const status = getStatus(currentStatus);
           const { blockTimestamps, transactionHashes } = getTransaction({

--- a/src/utils/history/getTransaction.ts
+++ b/src/utils/history/getTransaction.ts
@@ -24,7 +24,7 @@ const getTokenInfo = (tokenAddress: string) => {
       }
     }
   }
-  throw new Error(`Token address(${tokenAddress}) not found`);
+  return null;
 };
 
 export const getTransactionToken = (
@@ -32,8 +32,9 @@ export const getTransactionToken = (
   l2TokenAddress: string,
   amount: string,
   isL1: boolean
-): { l1Token: TransactionToken; l2Token: TransactionToken } => {
+): { l1Token: TransactionToken | null; l2Token: TransactionToken | null } => {
   const tokenInfo = getTokenInfo(isL1 ? l1TokenAddress : l2TokenAddress);
+  if (!tokenInfo) return { l1Token: null, l2Token: null };
   const l2Token: TransactionToken = {
     ...tokenInfo,
     address: l2TokenAddress,


### PR DESCRIPTION
## Summary

The tx history panel is sometimes not working because we did used different addresses for some tokens.

## Checklist

- [ ] Provided a screenshot (only if change is visible in UI)
- [ ] Provided steps for playback (only if possible).
- [ ] Provided a change scope in summary
- [ ] Local build has passed
