### PR TITLE
update deposit tx log search logic with topic hash

### DIFF
--- a/src/constant/contracts/tokens.ts
+++ b/src/constant/contracts/tokens.ts
@@ -8,6 +8,15 @@ import {
   TITAN_SEPOLIA_CONTRACTS,
   TOKAMAK_CONTRACTS,
 } from ".";
+import { ZERO_ADDRESS } from "../misc";
+
+export const ETH_ADDRESS_BY_CHAINID: Record<number, string> = {
+  [SupportedChainId.MAINNET]: ZERO_ADDRESS,
+  [SupportedChainId.SEPOLIA]: ZERO_ADDRESS,
+  [SupportedChainId.TITAN]: ZERO_ADDRESS,
+  [SupportedChainId.TITAN_SEPOLIA]: ZERO_ADDRESS,
+  [SupportedChainId.THANOS_SEPOLIA]: THANOS_SEPOLIA_CONTRACTS.ETH_ADDRESS,
+};
 
 export const WETH_ADDRESS_BY_CHAINID: Record<number, string> = {
   [SupportedChainId.MAINNET]: MAINNET_CONTRACTS.WETH_ADDRESS,
@@ -43,4 +52,27 @@ export const USDC_ADDRESS_BY_CHAINID: Record<number, string> = {
   [SupportedChainId.TITAN]: TOKAMAK_CONTRACTS.USDC_ADDRESS,
   [SupportedChainId.TITAN_SEPOLIA]: TITAN_SEPOLIA_CONTRACTS.USDC_ADDRESS,
   [SupportedChainId.THANOS_SEPOLIA]: THANOS_SEPOLIA_CONTRACTS.USDC_ADDRESS,
+};
+
+export const getTokenAddressByChainId = (
+  symbol: string,
+  chainId: SupportedChainId | undefined
+) => {
+  if (!chainId) return "";
+  switch (symbol) {
+    case "ETH":
+      return ETH_ADDRESS_BY_CHAINID[chainId];
+    case "TON":
+      return TON_ADDRESS_BY_CHAINID[chainId];
+    case "WETH":
+      return WETH_ADDRESS_BY_CHAINID[chainId];
+    case "WTON":
+      return WTON_ADDRESS_BY_CHAINID[chainId];
+    case "USDC":
+      return USDC_ADDRESS_BY_CHAINID[chainId];
+    case "USDT":
+      return USDT_ADDRESS_BY_CHAINID[chainId];
+    default:
+      return "";
+  }
 };

--- a/src/staging/constants/topicHash.ts
+++ b/src/staging/constants/topicHash.ts
@@ -1,0 +1,5 @@
+export const ERC20DepositInitiatedTopicHash =
+  "0x718594027abd4eaed59f95162563e0cc6d0e8d5b86b1c7be8b1b0ac3343d0396";
+
+export const ETHDepositInitiatedTopicHash =
+  "0x35d79ab81f2b2017e19afb5c5571778877782d7a8786f5907f93b0f4702f4f23";

--- a/src/staging/hooks/useBridgeHistory.ts
+++ b/src/staging/hooks/useBridgeHistory.ts
@@ -27,7 +27,7 @@ import {
   getCurretStatus,
 } from "@/utils/history/getCurrentStatus";
 import { useProvier } from "@/hooks/provider/useProvider";
-import { utils } from "ethers";
+import { ethers, utils } from "ethers";
 import { getDecodeLog } from "@/utils/history/getDecodeLog";
 import { formatAddress } from "@/utils/trim/formatAddress";
 import {
@@ -54,6 +54,8 @@ import {
 } from "../utils/getProvideStatus";
 import { mock_cancelRequest } from "@/test/crosstrade/_mock/mockdata";
 import { l2Provider } from "@/config/l2Provider";
+import L1TitanBridgeAbi from "@/abis/L1StandardBridge.json";
+import { getDecodedDepositLog } from "@/utils/history/getDecodedDepositLog";
 
 const getApolloClient = (chainId: number) => {
   return subgraphApolloClientsForHistory[chainId];
@@ -220,7 +222,7 @@ export const useWithdrawData = () => {
               ? SupportedChainId.TITAN
               : SupportedChainId.TITAN_SEPOLIA
           );
-
+          if (!l1Token || !l2Token) return;
           const status = getStatus(currentStatus);
           const { blockTimestamps, transactionHashes } = getTransaction({
             currentStatus,
@@ -307,13 +309,17 @@ export const useDepositData = () => {
             return;
           }
 
-          const logIndex = l1TxReceipt.logs.length - 1;
-          const isERC20Deposit = logIndex > 2;
-          const log = l1TxReceipt.logs[logIndex];
-          const { l1TokenAddress, l2TokenAddress, amount } = getDecodeLog(
-            isERC20Deposit,
-            log
+          const parsedLog = getDecodedDepositLog(
+            l1TxReceipt.logs,
+            new ethers.utils.Interface(L1TitanBridgeAbi),
+            isConnectedToMainNetwork
+              ? SupportedChainId.TITAN
+              : SupportedChainId.TITAN_SEPOLIA
           );
+
+          if (!parsedLog) return;
+
+          const { l1TokenAddress, l2TokenAddress, amount } = parsedLog;
 
           const { l1Token, l2Token } = getTransactionToken(
             l1TokenAddress,
@@ -324,6 +330,7 @@ export const useDepositData = () => {
               ? SupportedChainId.MAINNET
               : SupportedChainId.SEPOLIA
           );
+          if (!l1Token || !l2Token) return;
 
           const status = getStatus(currentStatus);
           const { blockTimestamps, transactionHashes } = getTransaction({

--- a/src/utils/history/getDecodedDepositLog.ts
+++ b/src/utils/history/getDecodedDepositLog.ts
@@ -1,0 +1,38 @@
+import {
+  THANOS_SEPOLIA_CONTRACTS,
+  TOKAMAK_CONTRACTS,
+} from "@/constant/contracts";
+import { providers, utils } from "ethers";
+import { ethers } from "ethers";
+import {
+  ERC20DepositInitiatedTopicHash,
+  ETHDepositInitiatedTopicHash,
+} from "@/staging/constants/topicHash";
+import { SupportedChainId } from "@/types/network/supportedNetwork";
+import { getTokenAddressByChainId } from "@/constant/contracts/tokens";
+
+export const getDecodedDepositLog = (
+  logs: providers.Log[],
+  iFace: utils.Interface,
+  chainId: SupportedChainId
+): {
+  l1TokenAddress: string;
+  l2TokenAddress: string;
+  amount: string;
+} | null => {
+  const log = logs.find(
+    (log: any) =>
+      log.topics[0] === ERC20DepositInitiatedTopicHash ||
+      log.topics[0] === ETHDepositInitiatedTopicHash
+  );
+  if (!log) return null;
+  const parsedLog = iFace.parseLog(log);
+  const { args } = parsedLog;
+  const { l1Token, l2Token, _l1Token, _l2Token, amount, _amount } = args;
+  return {
+    l1TokenAddress: l1Token ?? _l1Token ?? "",
+    l2TokenAddress:
+      l2Token ?? _l2Token ?? getTokenAddressByChainId("ETH", chainId),
+    amount: amount ? amount.toString() : _amount.toString(),
+  };
+};

--- a/src/utils/history/getTransaction.ts
+++ b/src/utils/history/getTransaction.ts
@@ -37,7 +37,7 @@ const getTokenInfo = (tokenAddress: string, chainId: number) => {
       }
     }
   }
-  throw new Error(`Token address(${tokenAddress}) not found`);
+  return null;
 };
 
 export const getTransactionToken = (
@@ -46,11 +46,12 @@ export const getTransactionToken = (
   amount: string,
   isL1: boolean,
   chainId: number
-): { l1Token: TransactionToken; l2Token: TransactionToken } => {
+): { l1Token: TransactionToken | null; l2Token: TransactionToken | null } => {
   const tokenInfo = getTokenInfo(
     isL1 ? l1TokenAddress : l2TokenAddress,
     chainId
   );
+  if (!tokenInfo) return { l1Token: null, l2Token: null };
   const l2Token: TransactionToken = {
     ...tokenInfo,
     address: l2TokenAddress,


### PR DESCRIPTION
## Summary

- Update deposit Tx log search logic with topic hash instead of log length
- Handle the errors which were being caused due to unsupported tokens

## Checklist

- [ ] Provided a screenshot (only if change is visible in UI)
- [ ] Provided steps for playback (only if possible).
- [ ] Provided a change scope in summary
- [ ] Local build has passed
