### PR TITLE
[BK-123] - fix a crash error after withdrawal 

### DIFF
--- a/src/hooks/history/useFinalize.ts
+++ b/src/hooks/history/useFinalize.ts
@@ -9,14 +9,16 @@ import useTxConfirmModal from "@/hooks/modal/useTxConfirmModal";
 import { useProvier } from "@/hooks/provider/useProvider";
 import { getWithdarwCalldata } from "@/utils/history/getWithdrawCalldata";
 import { WithdrawTransactionHistory } from "@/staging/types/transaction";
+import useDepositWithdrawConfirmModal from "@/staging/components/new-confirm/hooks/useDepositWithdrawConfirmModal";
 
 export const useFinalize = (params?: WithdrawTransactionHistory) => {
   const { isConnectedToMainNetwork, isLayer2 } = useConnectedNetwork();
   const { switchNetworkAsync } = useSwitchNetwork();
   const { L1MESSENGER_CONTRACT } = useContract();
-  const { setModalOpen } = useTxConfirmModal();
+  const { setModalOpen, setIsOpen } = useTxConfirmModal();
   const { L1Provider, L2Provider } = useProvier();
-
+  const { onCloseDepositWithdrawConfirmModal } =
+    useDepositWithdrawConfirmModal();
   const { data, write, isError } = useContractWrite({
     address: L1MESSENGER_CONTRACT,
     abi: L1CrossDomainMessenger_ABI,
@@ -37,22 +39,23 @@ export const useFinalize = (params?: WithdrawTransactionHistory) => {
         throw new Error("Not connected to any network");
       if (!L1Provider || !L2Provider) throw new Error("Provider not found");
       if (!params) throw new Error("params not found");
+      if (params)
+        if (isLayer2) {
+          const chainId = isConnectedToMainNetwork
+            ? SupportedChainId.MAINNET
+            : SupportedChainId.SEPOLIA;
+          const res = await switchNetworkAsync?.(chainId);
 
-      if (isLayer2) {
-        const chainId = isConnectedToMainNetwork
-          ? SupportedChainId.MAINNET
-          : SupportedChainId.SEPOLIA;
-        const res = await switchNetworkAsync?.(chainId);
-
-        //if user cancel or fail the network switch
-        if (!res) return;
-      }
+          //if user cancel or fail the network switch
+          if (!res) return;
+        }
 
       const { resolved, stateBatchAppended, blockNumber } = params;
 
       if (!stateBatchAppended) throw new Error("StateBatchAppended not found");
-
+      onCloseDepositWithdrawConfirmModal();
       //close detail modal and open confirming modal
+      setIsOpen(true);
       setModalOpen("confirming");
 
       const proof = await getWithdarwCalldata({

--- a/src/staging/components/new-confirm/components/core/other/ConfirmInitiateFooter.tsx
+++ b/src/staging/components/new-confirm/components/core/other/ConfirmInitiateFooter.tsx
@@ -75,11 +75,6 @@ export default function ConfirmInitiateFooter(
           <Text fontWeight={600} fontSize={"16px"} lineHeight={"24px"}>
             Initiate
           </Text>
-          {/* <Tooltip
-            tooltipLabel={"text will be changed"}
-            style={{ marginLeft: "2px" }}
-            type={isChecked ? "white" : "grey"}
-          /> */}
         </Button>
       </Box>
     </Box>

--- a/src/staging/components/new-confirm/components/core/other/StatusComponent.tsx
+++ b/src/staging/components/new-confirm/components/core/other/StatusComponent.tsx
@@ -191,7 +191,7 @@ export default function StatusComponent(props: StatusComponentProps) {
       )}
       {isTransaction && (
         <Link
-          target='_blank'
+          target="_blank"
           href={explorerUrl}
           textDecor={"none"}
           _hover={{ textDecor: "none" }}

--- a/src/staging/components/new-confirm/components/core/other/index.tsx
+++ b/src/staging/components/new-confirm/components/core/other/index.tsx
@@ -13,7 +13,12 @@ import {
 } from "@chakra-ui/react";
 import { useAccount } from "wagmi";
 import { trimAddress } from "@/utils/trim";
-import { Action, Status, GasCostData } from "@/staging/types/transaction";
+import {
+  Action,
+  Status,
+  GasCostData,
+  isWithdrawTransactionHistory,
+} from "@/staging/types/transaction";
 import useDepositWithdrawConfirmModal from "@/staging/components/new-confirm/hooks/useDepositWithdrawConfirmModal";
 import TimeLine from "./TimeLine";
 import CloseButton from "@/components/button/CloseButton";
@@ -37,6 +42,7 @@ import {
 import { getGasCostText } from "@/utils/number/compareNumbers";
 import useConnectedNetwork from "@/hooks/network";
 import useMediaView from "@/hooks/mediaView/useMediaView";
+import { useFinalize } from "@/hooks/history/useFinalize";
 
 export default function DepositWithdrawConfirmModal() {
   const { mobileView } = useMediaView();
@@ -57,6 +63,11 @@ export default function DepositWithdrawConfirmModal() {
    */
   const CLAIM_GAS_USED = 1000000;
   const withdrawCost = useRelayGas(CLAIM_GAS_USED, SupportedChainId["MAINNET"]);
+  const isWithdraw =
+    transactionData && isWithdrawTransactionHistory(transactionData);
+  const { callToFinalize } = useFinalize(
+    isWithdraw ? transactionData : undefined
+  );
 
   const gasCostData: GasCostData = useMemo(() => {
     const formatValue = (value: string | undefined | null) =>
@@ -103,6 +114,7 @@ export default function DepositWithdrawConfirmModal() {
      * - For DEPOSIT (length 2): One ConditionalBox component is inserted between the StatusComponent elements.
      */
   }
+
   const renderStatusComponents = (statuses: Status[]) => {
     return statuses.map((statusKey, index) => {
       const lineType = getLineType(transactionData);
@@ -289,9 +301,9 @@ export default function DepositWithdrawConfirmModal() {
                     backgroundColor: lineType !== 3 ? "#17181D" : "#007AFF",
                     color: lineType !== 3 ? "#8E8E92" : "#FFFFFF",
                   }}
-                  _active={{}}
                   _hover={{}}
                   _focus={{}}
+                  onClick={callToFinalize}
                 >
                   <Flex alignItems={"center"}>
                     <Text
@@ -301,11 +313,6 @@ export default function DepositWithdrawConfirmModal() {
                     >
                       Finalize
                     </Text>
-                    <Tooltip
-                      tooltipLabel={"text will be changed"}
-                      style={{ marginLeft: "2px" }}
-                      type={lineType !== 3 ? "grey" : "white"}
-                    />
                   </Flex>
                 </Button>
               )}

--- a/src/staging/components/new-confirm/utils/getConfirmType.ts
+++ b/src/staging/components/new-confirm/utils/getConfirmType.ts
@@ -77,7 +77,7 @@ const getWaitMessage = (lineType: number, index: number) => {
   const waitMessageMap: Record<number, string> = {
     0:
       index === 0
-        ? "Wait 6 hours"
+        ? "Wait up to 6 hours"
         : `Wait ${TRANSACTION_CONSTANTS.WITHDRAW.ROLLUP_DAYS} days`,
     1: `Wait ${TRANSACTION_CONSTANTS.WITHDRAW.ROLLUP_DAYS} days`,
     100: `Wait ${TRANSACTION_CONSTANTS.DEPOSIT.INITIAL_MINUTES} min`,

--- a/src/staging/components/new-history/components/core/pending/StatusComponent.tsx
+++ b/src/staging/components/new-history/components/core/pending/StatusComponent.tsx
@@ -171,12 +171,14 @@ export default function StatusComponent(
     needToCheck: shouldCountdown,
   });
 
+  const countdownTimeDisplay = useCountdown(
+    initialTimeDisplay,
+    Boolean(transactionData.errorMessage) || isTimeOver
+  );
+
   // Output variable
   const timeDisplay = shouldCountdown
-    ? useCountdown(
-        initialTimeDisplay,
-        Boolean(transactionData.errorMessage) || isTimeOver
-      )
+    ? countdownTimeDisplay
     : initialTimeDisplay;
 
   // Calendar start time

--- a/src/staging/components/new-history/components/core/pending/StatusComponent.tsx
+++ b/src/staging/components/new-history/components/core/pending/StatusComponent.tsx
@@ -83,11 +83,7 @@ const CalenderButtonComponent = (props: {
     </Flex>
   );
 };
-const FinalizeButtonComponent = (props: {
-  transactionData: WithdrawTransactionHistory;
-}) => {
-  const { callToFinalize } = useFinalize(props.transactionData);
-
+const FinalizeButtonComponent = (props: { openModal: () => void }) => {
   return (
     <Button
       w={"60px"}
@@ -102,7 +98,7 @@ const FinalizeButtonComponent = (props: {
       _active={{}}
       _hover={{}}
       _focus={{}}
-      onClick={callToFinalize}
+      onClick={props.openModal}
     >
       <Text fontWeight={600} fontSize={"11px"} lineHeight={"16.5px"}>
         Finalize
@@ -138,14 +134,6 @@ export default function StatusComponent(
       transactionData.status === CT_REQUEST_CANCEL.Refund ||
       transactionData.status === CT_PROVIDE.Return) &&
     isActive;
-
-  // if (shouldCountdown && transactionData.status === "Finalize") {
-  //   console.group();
-  //   console.log(transactionData.status);
-  //   console.log(getRemainTime(transactionData));
-  //   console.log(formatTimeDisplay(getRemainTime(transactionData)));
-  //   console.groupEnd();
-  // }
 
   const initialTimeDisplay = shouldCountdown
     ? // Value needed for countdown
@@ -304,7 +292,7 @@ export default function StatusComponent(
       </Flex>
       <Flex alignItems="center">
         {claimReadyButton ? (
-          <FinalizeButtonComponent transactionData={transactionData} />
+          <FinalizeButtonComponent openModal={openModal} />
         ) : (
           <Text
             fontSize={"11px"}

--- a/src/staging/components/new-history/components/core/pending/StatusComponent.tsx
+++ b/src/staging/components/new-history/components/core/pending/StatusComponent.tsx
@@ -139,7 +139,7 @@ export default function StatusComponent(
       transactionData.status === CT_PROVIDE.Return) &&
     isActive;
 
-  // if (shouldCountdown && rollupStage) {
+  // if (shouldCountdown && transactionData.status === "Finalize") {
   //   console.group();
   //   console.log(transactionData.status);
   //   console.log(getRemainTime(transactionData));

--- a/src/staging/components/new-history/utils/getTimeDisplay.ts
+++ b/src/staging/components/new-history/utils/getTimeDisplay.ts
@@ -47,7 +47,7 @@ export function getRemainTime(transactionData: TransactionHistory): number {
         const timeValue = calculateInitialTime(
           statusValue,
           transactionData.blockTimestamps.rollupCompletedTimestamp,
-          TRANSACTION_CONSTANTS.WITHDRAW.ROLLUP_SECS
+          TRANSACTION_CONSTANTS.WITHDRAW.CHALLENGE_SECS
         );
         return timeValue;
       }

--- a/src/staging/hooks/useBridgeHistory.ts
+++ b/src/staging/hooks/useBridgeHistory.ts
@@ -239,7 +239,7 @@ export const useWithdrawData = () => {
           const result: WithdrawTransactionHistory = {
             category: HISTORY_SORT.STANDARD,
             action: Action.Withdraw,
-            status: status,
+            status,
             inNetwork: SupportedChainId.TITAN,
             outNetwork: SupportedChainId.MAINNET,
             inToken: l2Token,

--- a/src/staging/hooks/useBridgeHistory.ts
+++ b/src/staging/hooks/useBridgeHistory.ts
@@ -240,8 +240,12 @@ export const useWithdrawData = () => {
             category: HISTORY_SORT.STANDARD,
             action: Action.Withdraw,
             status,
-            inNetwork: SupportedChainId.TITAN,
-            outNetwork: SupportedChainId.MAINNET,
+            inNetwork: isConnectedToMainNetwork
+              ? SupportedChainId.TITAN
+              : SupportedChainId.TITAN_SEPOLIA,
+            outNetwork: isConnectedToMainNetwork
+              ? SupportedChainId.MAINNET
+              : SupportedChainId.SEPOLIA,
             inToken: l2Token,
             outToken: l1Token,
             blockNumber: Number(sentMessage.blockNumber),
@@ -263,6 +267,7 @@ export const useWithdrawData = () => {
           previousTx.blockTimestamps.initialCompletedTimestamp -
           currentTx.blockTimestamps.initialCompletedTimestamp
       );
+      console.log("sortedResult", sortedResult);
 
       if (sortedResult) return setWithdrawHistory(sortedResult);
       return setWithdrawHistory([]);

--- a/src/utils/history/getTransaction.ts
+++ b/src/utils/history/getTransaction.ts
@@ -81,11 +81,11 @@ export const getDepositStatus = (currentStatus: CurrentDepositStatus) => {
 export const getStatus = (currentStatus: CurrentStatus) => {
   switch (currentStatus) {
     case 0:
-      return Status.Initiate;
+      return Status.Rollup;
     case 1:
-      return Status.Rollup;
+      return Status.Finalize;
     case 2:
-      return Status.Rollup;
+      return Status.Finalize;
     case 3:
       return Status.Finalize;
     case 4:
@@ -120,9 +120,6 @@ export const getTransactionTimestamp = (params: {
 
   switch (currentStatus) {
     case 0:
-      return {
-        initialCompletedTimestamp,
-      };
     case 1:
     case 2:
       return {


### PR DESCRIPTION
## Summary
- Remove the unconditional use of useCountdown to fix a crash bug on the Withdraw History tab.
- Bind the finalize function to the Finalize button in the Confirm Withdraw modal.
- Update the Finalize button in the pendingFooter to open the Confirm Withdraw modal.

## Checklist

- [ ] Provided a screenshot (only if change is visible in UI)
- [ ] Provided steps for playback (only if possible).
- [ ] Provided a change scope in summary
- [x] Local build has passed
