### PR TITLE
 [BK-126] - Update UI for relay time changes

### DIFF
--- a/src/components/history/DepositStatusTx.tsx
+++ b/src/components/history/DepositStatusTx.tsx
@@ -92,7 +92,7 @@ export default function DepositStatusTx(props: {
             cursor={"pointer"}
             color={mobileView ? "#A0A3AD" : ""}
             _hover={{
-              textDecoration: mobileView ? "none" : "underline"
+              textDecoration: mobileView ? "none" : "underline",
             }}
           >
             {mobileView ? "Deposit" : `${layer}: Completed`}
@@ -109,7 +109,7 @@ export default function DepositStatusTx(props: {
           </Link>
         ) : (
           <Text fontSize={"11px"} fontWeight={600}>
-            {`${layer}: Wait ~5 min for relay`}
+            {`${layer}: Wait ~15 min for relay`}
           </Text>
         )}
       </Flex>
@@ -122,7 +122,10 @@ export default function DepositStatusTx(props: {
           >
             <Flex fontSize={"11px"}>
               <Text color={mobileView ? "#A0A3AD" : "#FFFFFF"}>
-                <Flex gap="4px" >Transaction<Image alt="txmove" src={txMove} /></Flex>
+                <Flex gap="4px">
+                  Transaction
+                  <Image alt="txmove" src={txMove} />
+                </Flex>
               </Text>
               {!mobileView && (
                 <Text ml="3px" color={"#A0A3AD"}>

--- a/src/hooks/transactionDetail/useTransactionDetail.ts
+++ b/src/hooks/transactionDetail/useTransactionDetail.ts
@@ -93,7 +93,7 @@ export function useTransactionDetail() {
         ? [
             {
               title: "Time to Deposit",
-              content: "~5 minutes",
+              content: "~15 minutes",
             },
             {
               title: "Network fee",
@@ -124,7 +124,7 @@ export function useTransactionDetail() {
             },
             {
               title: "Time to Deposit",
-              content: "~5 minutes",
+              content: "~15 minutes",
             },
           ];
     }

--- a/src/staging/components/cross-trade/components/core/comfirm/CTConfirmDetail.tsx
+++ b/src/staging/components/cross-trade/components/core/comfirm/CTConfirmDetail.tsx
@@ -69,7 +69,7 @@ const CTTransactionDetail: React.FC<TransactionDetailProps> = ({
           return (
             <span>
               Total amount to receive, including the service
-              <br /> fee. It takes at least 2~5 minutes to receive <br />{" "}
+              <br /> fee. It takes at least 15 minutes to receive <br />{" "}
               (depending on the L2 sequencer).
             </span>
           );

--- a/src/staging/components/cross-trade/components/core/comfirm/CTConfirmHistoryFooter.tsx
+++ b/src/staging/components/cross-trade/components/core/comfirm/CTConfirmHistoryFooter.tsx
@@ -129,7 +129,7 @@ const TransactionItem = (props: TransactionItemProps) => {
             }}
             tooltipLabel={
               <span>
-                It take at least 2~5 minutes to receive <br />
+                It take at least 15 minutes to receive <br />
                 (depending on the L2 sequencer).{" "}
               </span>
             }
@@ -147,7 +147,7 @@ const TransactionItem = (props: TransactionItemProps) => {
             }}
             tooltipLabel={
               <span>
-                The refund takes at least 2~5 minutes
+                The refund takes at least 15 minutes
                 <br />
                 (depending on the L2 sequencer).{" "}
               </span>

--- a/src/staging/components/cross-trade/components/core/main/CTMain.tsx
+++ b/src/staging/components/cross-trade/components/core/main/CTMain.tsx
@@ -389,8 +389,8 @@ export default function CTMain() {
                   tooltipLabel={
                     <span>
                       Total amount to receive, including the service
-                      <br /> fee. It takes at least 2~5 minutes to receive{" "}
-                      <br /> (depending on the L2 sequencer).
+                      <br /> fee. It takes at least 15 minutes to receive <br />{" "}
+                      (depending on the L2 sequencer).
                     </span>
                   }
                   style={{

--- a/src/staging/components/cross-trade/components/core/main/TokenDetail.tsx
+++ b/src/staging/components/cross-trade/components/core/main/TokenDetail.tsx
@@ -26,8 +26,6 @@ const Percentage = (props: { percent: string }) => {
   const isNegative = props.percent.includes("-");
   const isZero = Number(props.percent) === 0;
 
-  if (isZero) console.log(props.percent);
-
   return (
     <Text
       fontSize={14}

--- a/src/staging/components/cross-trade/components/core/updateFee/index.tsx
+++ b/src/staging/components/cross-trade/components/core/updateFee/index.tsx
@@ -472,7 +472,7 @@ export default function CTFeeUpdateModal() {
                   fontSize={12}
                   lineHeight={"20px"}
                 >
-                  refund may take at least 2~5 minutes <br />
+                  refund may take at least 15 minutes <br />
                   (depending on L2 sequencer).
                 </Text>
               </Flex>

--- a/src/staging/constants/transactionTime.ts
+++ b/src/staging/constants/transactionTime.ts
@@ -11,11 +11,12 @@ export const TRANSACTION_CONSTANTS = {
     ROLLUP_DAYS: 7, // Duration of the rollup state for withdrawal (in days)
     CHALLENGE_SECS: 604800,
   },
+  // Set to 15sec time-buffer for UI purposes, although the spec is 900 seconds
   CROSS_TRADE: {
-    PROVIDE: 900, //15 minutes in seconds
-    REQUEST: 900,
-    CANCEL_REQUEST: 900,
-    RETURN_LIQUIDITY: 900,
+    PROVIDE: 915, //15 minutes in seconds
+    REQUEST: 915, 
+    CANCEL_REQUEST: 915,
+    RETURN_LIQUIDITY: 915,
   },
 };
 

--- a/src/staging/constants/transactionTime.ts
+++ b/src/staging/constants/transactionTime.ts
@@ -13,9 +13,9 @@ export const TRANSACTION_CONSTANTS = {
   },
   CROSS_TRADE: {
     PROVIDE: 900, //15 minutes in seconds
-    REQUEST: 300,
-    CANCEL_REQUEST: 300,
-    RETURN_LIQUIDITY: 300,
+    REQUEST: 900,
+    CANCEL_REQUEST: 900,
+    RETURN_LIQUIDITY: 900,
   },
 };
 


### PR DESCRIPTION
## Summary
- Change all tooltip for relay time (2~5 min -> 15min)
- Apply 15sec timebuffer to Cross Trade count down
- CLS 

## Checklist

- [ ] Provided a screenshot (only if change is visible in UI)
- [ ] Provided steps for playback (only if possible).
- [ ] Provided a change scope in summary
- [x] Local build has passed
