### PR TITLE
[BK-127] - hotfix_3

### DIFF
--- a/src/components/tooltip/CustomTooltip.tsx
+++ b/src/components/tooltip/CustomTooltip.tsx
@@ -18,7 +18,10 @@ export default function CustomTooltip(props: {
     px?: string;
     py?: string;
     tooltipLineHeight?: string;
+    left?: string;
   };
+  labelStyle?: CSSProperties;
+  tooltipArrowStyle?: CSSProperties;
   needArrow?: boolean;
 }) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -47,6 +50,7 @@ export default function CustomTooltip(props: {
           color={"#fff"}
           pos={"relative"}
           {...props.style}
+          style={props.labelStyle}
         >
           <Text
             w={"100%"}
@@ -77,7 +81,13 @@ export default function CustomTooltip(props: {
       >
         {props.content}
         {arrowNeeded && isOpen && (
-          <Box pos={"absolute"} top={"-12px"} left={"4px"} zIndex={100}>
+          <Box
+            pos={"absolute"}
+            top={"-12px"}
+            left={"4px"}
+            zIndex={100}
+            style={props.tooltipArrowStyle}
+          >
             <Image src={TooltipArrow} alt={"TooltipArrow"}></Image>
           </Box>
         )}

--- a/src/staging/components/cross-trade/components/core/comfirm/CTConfirmDetail.tsx
+++ b/src/staging/components/cross-trade/components/core/comfirm/CTConfirmDetail.tsx
@@ -342,6 +342,15 @@ export default function CTConfirmDetail({
       : CTTransactionType.requestRegisteredToken
   );
 
+  const showServiceFee = useMemo(() => {
+    return (
+      !isCanceled &&
+      (updateFee ||
+        (modalType === ModalType.History && !isInCT_Provide(status))) &&
+      !isProvide
+    );
+  }, [isCanceled, updateFee, modalType, status, isProvide]);
+
   return (
     <Box
       bg="#15161D"
@@ -375,7 +384,7 @@ export default function CTConfirmDetail({
             outNetwork={isProvide ? inNetwork : outNetwork}
           />
         )}
-        {!isCanceled && updateFee && !isProvide && (
+        {showServiceFee && (
           <FeeDetail
             title="Service fee"
             mainAmount={`${commafy(serviceFee)} ${sendTokenInfo.tokenSymbol}`}

--- a/src/staging/components/cross-trade/components/core/main/CTMain.tsx
+++ b/src/staging/components/cross-trade/components/core/main/CTMain.tsx
@@ -344,7 +344,7 @@ export default function CTMain() {
                 <CustomTooltipWithQuestion
                   isGrayIcon={true}
                   tooltipLabel={"Total amount to pay."}
-                  containerSyle={{ marginLeft: "2px" }}
+                  containerSyle={{ marginLeft: "2px", fontSize: "12px" }}
                 />
               </Flex>
             </Th>
@@ -387,15 +387,15 @@ export default function CTMain() {
                 <CustomTooltipWithQuestion
                   isGrayIcon={true}
                   tooltipLabel={
-                    <span>
+                    <span style={{ fontSize: 12 }}>
                       Total amount to receive, including the service
                       <br /> fee. It takes at least 15 minutes to receive <br />{" "}
                       (depending on the L2 sequencer).
                     </span>
                   }
                   style={{
-                    width: "268px",
-                    height: "70px",
+                    width: "289px",
+                    height: "74px",
                     tooltipLineHeight: "normal",
                     py: "10px",
                     px: "8px",
@@ -436,8 +436,32 @@ export default function CTMain() {
                   color={"#A0A3AD"}
                   letterSpacing={0}
                 >
-                  Net Profit (%)
+                  Net Profit
                 </Text>
+                <CustomTooltipWithQuestion
+                  isGrayIcon={true}
+                  tooltipLabel={
+                    <span style={{ fontSize: 12 }}>
+                      <span style={{ fontWeight: 600 }}>
+                        Net Profit = Receive - Provide - txn fee
+                      </span>
+                      <br />
+                      Net profit for provider is heavily depends on the
+                      <br />
+                      transaction fee, which is a highly volatile value.
+                      <br />
+                      Please double-check it before providing.
+                    </span>
+                  }
+                  style={{
+                    width: "300px",
+                    height: "92px",
+                    tooltipLineHeight: "normal",
+                    py: "10px",
+                    px: "8px",
+                  }}
+                  containerSyle={{ marginLeft: "2px" }}
+                />
               </Flex>
             </Th>
             <Th textTransform="none"></Th>
@@ -535,6 +559,7 @@ export default function CTMain() {
                     <TokenDetail
                       profit={item.profit}
                       providingUSD={item.providingUSD}
+                      provideCTTxnCost={item.provideCTTxnCost}
                     />
                   </Td>
                   <Td>

--- a/src/staging/components/cross-trade/components/core/main/CTMain.tsx
+++ b/src/staging/components/cross-trade/components/core/main/CTMain.tsx
@@ -211,6 +211,9 @@ export default function CTMain() {
             : chainNameOut === "TITAN_SEPOLIA"
             ? "Titan Sepolia"
             : capitalizeFirstLetter(chainNameOut);
+        const isNegativeProfit = item.profit?.percent
+          ? Number(item.profit?.percent) < 0
+          : false;
 
         return (
           <Box
@@ -243,7 +246,7 @@ export default function CTMain() {
                   >
                     Receive on {displayNetworkNameIn}
                   </Text>
-                  <Flex alignItems={"center"}>
+                  <Flex alignItems={"center"} columnGap={"6px"}>
                     <Text
                       fontSize="16px"
                       fontWeight={600}
@@ -253,14 +256,14 @@ export default function CTMain() {
                     >
                       {formatNumber(formattedAmount)} {item.outToken.symbol}
                     </Text>
-                    <Text fontSize="13px" fontWeight={400} lineHeight="19.5px">
-                      (
-                    </Text>
-                    <Text fontSize="16px" fontWeight={400} lineHeight="24px">
-                      +{formatProfit(item.profit?.percent)}%
-                    </Text>
-                    <Text fontSize="13px" fontWeight={400} lineHeight="19.5px">
-                      )
+                    <Text
+                      fontSize="16px"
+                      fontWeight={400}
+                      lineHeight="24px"
+                      color={isNegativeProfit ? "#DD3A44" : "#03D187"}
+                    >
+                      {!isNegativeProfit && "+"}
+                      {formatProfit(item.profit?.percent)}%
                     </Text>
                   </Flex>
                   <Text

--- a/src/staging/components/cross-trade/components/core/main/TokenDetail.tsx
+++ b/src/staging/components/cross-trade/components/core/main/TokenDetail.tsx
@@ -20,6 +20,7 @@ interface TokenDetailProps {
   providingUSD?: number;
   recevingUSD?: number;
   profit?: Profit;
+  provideCTTxnCost?: number;
 }
 
 const Percentage = (props: { percent: string }) => {
@@ -55,18 +56,54 @@ const USDValue = (props: { usdAmount: string }) => {
   );
 };
 
-const NetProfit = (props: { percent: string; usdAmount: string }) => {
+const NetProfit = (props: {
+  percent: string;
+  usdAmount: string;
+  provideCTTxnCost?: number;
+}) => {
   return (
-    <Flex flexDir={"column"}>
-      <Percentage {...props}></Percentage>
-      <USDValue {...props}></USDValue>
-    </Flex>
+    <CustomTooltip
+      content={
+        <Flex flexDir={"column"}>
+          <Percentage {...props}></Percentage>
+          <USDValue {...props}></USDValue>
+        </Flex>
+      }
+      tooltipLabel={
+        <Flex alignItems={"center"} h={"100%"}>
+          <Box lineHeight={"normal"} fontSize={12}>
+            <span>Estimated net profit based on transaction</span>
+            <br />
+            {`fee of $
+            ${commafy(props.provideCTTxnCost)}
+            Actual value may differ based on
+           other factors (priority fee, storage refund, etc)`}
+          </Box>
+        </Flex>
+      }
+      needArrow={true}
+      labelStyle={{
+        left: "-17px",
+        width: "291px",
+        height: "74px",
+      }}
+      tooltipArrowStyle={{
+        left: "25px",
+      }}
+    ></CustomTooltip>
   );
 };
 
 export default function TokenDetail(props: TokenDetailProps) {
-  const { token, network, profit, isProvide, providingUSD, recevingUSD } =
-    props;
+  const {
+    token,
+    network,
+    profit,
+    isProvide,
+    providingUSD,
+    recevingUSD,
+    provideCTTxnCost,
+  } = props;
   const isProfit = profit !== undefined;
 
   const formattedAmount = token
@@ -88,7 +125,11 @@ export default function TokenDetail(props: TokenDetailProps) {
 
   if (isProfit) {
     return (
-      <NetProfit percent={priceOrPercent} usdAmount={commafy(profit.usd)} />
+      <NetProfit
+        percent={priceOrPercent}
+        usdAmount={commafy(profit.usd)}
+        provideCTTxnCost={provideCTTxnCost}
+      />
     );
   }
 

--- a/src/staging/hooks/useCrossTrade.ts
+++ b/src/staging/hooks/useCrossTrade.ts
@@ -356,6 +356,7 @@ export const useRequestData = (
             initialCTAmount: item._ctAmount,
             editedCTAmount: ctAmount,
             isNetaveProfit: profitRatio.toFixed(30).includes("-"),
+            provideCTTxnCost: txnCost,
           };
         });
 

--- a/src/staging/types/crossTrade.ts
+++ b/src/staging/types/crossTrade.ts
@@ -37,4 +37,5 @@ export interface CrossTradeData {
   initialCTAmount: string;
   editedCTAmount: bigint;
   isNetaveProfit: boolean;
+  provideCTTxnCost: number;
 }


### PR DESCRIPTION
## Summary
- Fix completed label design
- Remove adjust fee mechanism
- Estimate network fee when estimating call is reverted on the Confirm Provide modal
- Show service fee on the Request History modal
- Net Profit tooltips
- Net Profit style on mobile

## Checklist

- [ ] Provided a screenshot (only if change is visible in UI)
- [ ] Provided steps for playback (only if possible).
- [ ] Provided a change scope in summary
- [x] Local build has passed
