### PR TITLE
[BK-127] - Sort requests by profit in descending order by default

### DIFF
--- a/src/staging/components/cross-trade/components/core/main/CTMain.tsx
+++ b/src/staging/components/cross-trade/components/core/main/CTMain.tsx
@@ -61,6 +61,10 @@ export default function CTMain() {
     }
   }, [requestList]);
 
+  /**
+   * TO DO: refactor sort process to be moved into a custom hook
+   *
+   */
   useEffect(() => {
     if (isDescSortedProvide === null) return;
     if (isDescSortedProvide) {

--- a/src/staging/hooks/useCrossTrade.ts
+++ b/src/staging/hooks/useCrossTrade.ts
@@ -344,7 +344,7 @@ export const useRequestData = (
               amount: profitAmount.toString(),
               symbol: isETH ? "ETH" : (tokenInfo?.tokenSymbol as string),
               usd: profitUSD,
-              percent: percent.toFixed(30),
+              percent: percent.toFixed(4),
               decimals: tokenInfo?.decimals as number,
             },
             blockTimestamps: Number(item.blockTimestamp),
@@ -366,6 +366,10 @@ export const useRequestData = (
 
         const trimedResult = result.filter(
           (item) => !item.isCanceled && !item.isProvided
+        );
+
+        trimedResult.sort(
+          (a, b) => Number(b.profit.percent) - Number(a.profit.percent)
         );
 
         setIsLoading(false);


### PR DESCRIPTION
## Summary
- Sorting the remaining requests based on the profit percent in descending order.

## Checklist
- [ ] Provided a screenshot (only if change is visible in UI)
- [ ] Provided steps for playback (only if possible).
- [ ] Provided a change scope in summary
- [x] Local build has passed
